### PR TITLE
Check architecture before launching debootstrap

### DIFF
--- a/debian_on_termux.sh
+++ b/debian_on_termux.sh
@@ -13,6 +13,7 @@ ARCHITECTURE=$(uname -m)
 case $ARCHITECTURE in    # supported architectures include: armel, armhf, arm64, i386, amd64
 	aarch64) ARCHITECTURE=arm64 ;;
 	x86_64) ARCHITECTURE=amd64 ;;
+	armv7l) ARCHITECTURE=armhf ;;
 	armel|armhf|arm64|i386|amd64) ;;
 	*) echo "Unsupported architecture $ARCHITECTURE"; exit ;;
 esac

--- a/debian_on_termux.sh
+++ b/debian_on_termux.sh
@@ -9,8 +9,14 @@ DO_FIRST_STAGE=: # false   # required (unpack phase/ executes outside guest invi
 DO_SECOND_STAGE=: # false  # required (complete the install/ executes inside guest invironment)
 DO_THIRD_STAGE=: # false   # optional (enable local policies/ executes inside guest invironment)
 
-ARCHITECTURE=$(uname -m | sed 's/aarch64/arm64/g ; s/x86_64/amd64/g')
-                           # supported architectures include: armel, armhf, arm64, i386, amd64
+ARCHITECTURE=$(uname -m)
+case $ARCHITECTURE in    # supported architectures include: armel, armhf, arm64, i386, amd64
+	aarch64) ARCHITECTURE=arm64 ;;
+	x86_64) ARCHITECTURE=amd64 ;;
+	armel|armhf|arm64|i386|amd64) ;;
+	*) echo "Unsupported architecture $ARCHITECTURE"; exit ;;
+esac
+
 VERSION=stable             # supported debian versions include: stretch, stable, testing, unstable
 ROOTFS_TOP=deboot_debian   # name of the top install directory
 ZONEINFO=Europe/Berlin     # set your desired time zone

--- a/debian_on_termux.sh
+++ b/debian_on_termux.sh
@@ -14,7 +14,7 @@ case $ARCHITECTURE in    # supported architectures include: armel, armhf, arm64,
 	aarch64) ARCHITECTURE=arm64 ;;
 	x86_64) ARCHITECTURE=amd64 ;;
 	armv7l) ARCHITECTURE=armhf ;;
-	armel|armhf|arm64|i386|amd64) ;;
+	armel|armhf|arm64|i386|amd64|mips|mips64el|mipsel|ppc64el|s390x) ;; # Officially supported Debian Stretch architectures
 	*) echo "Unsupported architecture $ARCHITECTURE"; exit ;;
 esac
 


### PR DESCRIPTION
Termux could give an architecture which is not an officially named Debian architecture.
In the code there is already a mapping for aarch64 and x86_64.

I propose to use a case statement to map non Debian arch to official Debian arch names and to check if the detected architecture is indeed an official one.

I have also added a mapping for armv7l arch to armhf to fix the execution on my Fairphone2 (Android 6.0.1/Termux 0.65)