### PR TITLE
Install in home directory

### DIFF
--- a/debian_on_termux_10.sh
+++ b/debian_on_termux_10.sh
@@ -26,7 +26,7 @@ if [ ! -d ~/debian-$BRANCH ] ; then
 		--exclude=systemd \
 		--arch=$ARCH \
 		$BRANCH \
-		debian-$BRANCH \
+		~/debian-$BRANCH \
 		$REPO
 fi
 unset LD_PRELOAD


### PR DESCRIPTION
The script bootstraped debian in the current directory, but expects it to be in the home directory. Changed install path.